### PR TITLE
feat: accept signer callback

### DIFF
--- a/src/did_indy/author/lite.py
+++ b/src/did_indy/author/lite.py
@@ -1,6 +1,5 @@
 """Lite Author implementation."""
 
-from typing import Protocol
 from did_indy.author.base import BaseAuthor
 from did_indy.anoncreds import (
     CredDefTypes,
@@ -20,15 +19,8 @@ from did_indy.driver.api.txns import (
     RevStatusListSubmitResponse,
     SchemaSubmitResponse,
 )
+from did_indy.signer import Signer, sign_message
 from did_indy.models.taa import TaaAcceptance
-
-
-class Signer(Protocol):
-    """Signer Protocol."""
-
-    async def __call__(self, signature_input: bytes) -> bytes:
-        """Sign signature input."""
-        ...
 
 
 class AuthorLite(BaseAuthor):
@@ -62,7 +54,7 @@ class AuthorLite(BaseAuthor):
         """Register a schema."""
         schema = normalize_schema_representation(schema)
         txn = await self.client.create_schema(schema.model_dump(), taa)
-        sig = await self.signer(txn.get_signature_input_bytes())
+        sig = await sign_message(self.signer, txn.get_signature_input_bytes())
         result = await self.client.submit_schema(schema.issuer_id, txn.request, sig)
         return result
 
@@ -74,7 +66,7 @@ class AuthorLite(BaseAuthor):
         """Register a credential definition."""
         cred_def = normalize_cred_def_representation(cred_def)
         txn = await self.client.create_cred_def(cred_def.model_dump(), taa)
-        sig = await self.signer(txn.get_signature_input_bytes())
+        sig = await sign_message(self.signer, txn.get_signature_input_bytes())
         result = await self.client.submit_cred_def(cred_def.issuer_id, txn.request, sig)
         return result
 
@@ -86,7 +78,7 @@ class AuthorLite(BaseAuthor):
         """Register a revocation registry definition."""
         rev_reg_def = normalize_rev_reg_def_representation(rev_reg_def)
         txn = await self.client.create_rev_reg_def(rev_reg_def.model_dump(), taa)
-        sig = await self.signer(txn.get_signature_input_bytes())
+        sig = await sign_message(self.signer, txn.get_signature_input_bytes())
         result = await self.client.submit_rev_reg_def(
             rev_reg_def.issuer_id, txn.request, sig
         )
@@ -102,7 +94,7 @@ class AuthorLite(BaseAuthor):
         txn = await self.client.create_rev_status_list(
             rev_status_list.model_dump(), taa
         )
-        sig = await self.signer(txn.get_signature_input_bytes())
+        sig = await sign_message(self.signer, txn.get_signature_input_bytes())
         result = await self.client.submit_rev_status_list(
             rev_status_list.issuer_id, txn.request, sig
         )
@@ -121,7 +113,7 @@ class AuthorLite(BaseAuthor):
         txn = await self.client.update_rev_status_list(
             prev_list.current_accumulator, curr_list.model_dump(), revoked, taa
         )
-        sig = await self.signer(txn.get_signature_input_bytes())
+        sig = await sign_message(self.signer, txn.get_signature_input_bytes())
         result = await self.client.submit_rev_status_list_update(
             curr_list.issuer_id, txn.request, sig
         )

--- a/src/did_indy/driver/api/txns.py
+++ b/src/did_indy/driver/api/txns.py
@@ -128,7 +128,7 @@ async def post_nym(
             version=version,
         )
         try:
-            result = await ledger.submit(request, key, taa)
+            result = await ledger.submit(request, key.sign_message, taa)
         except VdrError as error:
             if error.code == VdrErrorCode.POOL_REQUEST_FAILED:
                 raise HTTPException(400, detail=str(error))
@@ -248,7 +248,7 @@ async def post_schema_submit(
             submitter=submitter.nym,
             submitter_signature=req.signature,
             nym=nym,
-            key=key,
+            signer=key.sign_message,
         )
 
     result = TxnResult[SchemaTxnData].model_validate(result)
@@ -308,7 +308,7 @@ async def post_schema_endorse(
         raise HTTPException(400, detail="Incorrect endorser nym on request")
 
     async with Ledger(pool) as ledger:
-        endorsement = await ledger.endorse(req.request, nym, key)
+        endorsement = await ledger.endorse(req.request, nym, key.sign_message)
 
     return EndorseResponse(
         nym=endorsement.nym,
@@ -406,7 +406,7 @@ async def post_cred_def_submit(
             submitter=submitter.nym,
             submitter_signature=req.signature,
             nym=nym,
-            key=key,
+            signer=key.sign_message,
         )
         result = TxnResult[CredDefTxnData].model_validate(result)
 
@@ -444,7 +444,7 @@ async def post_cred_def_endorse(
         raise HTTPException(400, detail="Incorrect endorser nym on request")
 
     async with Ledger(pool) as ledger:
-        endorsement = await ledger.endorse(req.request, nym, key)
+        endorsement = await ledger.endorse(req.request, nym, key.sign_message)
 
     return EndorseResponse(
         nym=endorsement.nym,
@@ -534,7 +534,7 @@ async def post_rev_reg_def_submit(
             submitter=submitter.nym,
             submitter_signature=req.signature,
             nym=nym,
-            key=key,
+            signer=key.sign_message,
         )
         result = TxnResult[RevRegDefTxnData].model_validate(result)
 
@@ -572,7 +572,7 @@ async def post_rev_reg_def_endorse(
         raise HTTPException(400, detail="Incorrect endorser nym on request")
 
     async with Ledger(pool) as ledger:
-        endorsement = await ledger.endorse(req.request, nym, key)
+        endorsement = await ledger.endorse(req.request, nym, key.sign_message)
 
     return EndorseResponse(
         nym=endorsement.nym,
@@ -663,7 +663,7 @@ async def post_rev_status_list_submit(
             submitter=submitter.nym,
             submitter_signature=req.signature,
             nym=nym,
-            key=key,
+            signer=key.sign_message,
         )
         result = TxnResult[RevRegEntryTxnData].model_validate(result)
 
@@ -697,7 +697,7 @@ async def post_rev_status_list_endorse(
         raise HTTPException(400, detail="Incorrect endorser nym on request")
 
     async with Ledger(pool) as ledger:
-        endorsement = await ledger.endorse(req.request, nym, key)
+        endorsement = await ledger.endorse(req.request, nym, key.sign_message)
 
     return EndorseResponse(
         nym=endorsement.nym,
@@ -780,7 +780,7 @@ async def post_rev_status_list_update_submit(
             submitter=submitter.nym,
             submitter_signature=req.signature,
             nym=nym,
-            key=key,
+            signer=key.sign_message,
         )
         result = TxnResult[RevRegEntryTxnData].model_validate(result)
 
@@ -814,7 +814,7 @@ async def post_rev_status_list_update_endorse(
         raise HTTPException(400, detail="Incorrect endorser nym on request")
 
     async with Ledger(pool) as ledger:
-        endorsement = await ledger.endorse(req.request, nym, key)
+        endorsement = await ledger.endorse(req.request, nym, key.sign_message)
 
     return EndorseResponse(
         nym=endorsement.nym,

--- a/src/did_indy/signer.py
+++ b/src/did_indy/signer.py
@@ -1,0 +1,20 @@
+"""Signature abstraction to enable flexible cryptography backends."""
+
+from typing import Awaitable, Callable
+
+Signer = Callable[[bytes], bytes | Awaitable[bytes]]
+
+
+async def sign_message(sign: Signer, message: bytes) -> bytes:
+    """Sign a message.
+
+    The signer must either be a callable returning bytes or a callable returning
+    an awaitable of bytes.
+    """
+    value = sign(message)
+    if isinstance(value, bytes):
+        return value
+
+    # If you give anything other than an awaitable, this will raise a TypeError.
+    # Callers be warned!
+    return await value


### PR DESCRIPTION
Instead of exclusively operating with Askar Keys. This has the benefit of greater flexibility with providing signatures over ledger txns. Also means there's not a strict dependency on Askar anymore to use the ledger components.