### PR TITLE
fix: use correct route to retrieve namespaces

### DIFF
--- a/src/did_indy/client/client.py
+++ b/src/did_indy/client/client.py
@@ -104,7 +104,7 @@ class IndyDriverClient(HTTPClient):
 
     async def get_namespaces(self) -> List[str]:
         """Get namespaces."""
-        result = await self.get("/namespace")
+        result = await self.get("/info")
         return result["namespaces"]
 
     async def get_taa(self, namespace: str) -> TAAInfo:


### PR DESCRIPTION
The driver API uses /info instead of /namespace, so I made a fix to the client side of the interaction