### PR TITLE
refactor: revocation status list retrieval

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.1
     hooks:
-      - id: ruff
+      - id: ruff-check
         stages: [pre-commit]
         args: ["--fix", "--exit-non-zero-on-fix"]
       - id: ruff-format

--- a/src/did_indy/anoncreds.py
+++ b/src/did_indy/anoncreds.py
@@ -5,19 +5,20 @@ from typing import Any
 
 from anoncreds import (
     CredentialDefinition,
-    RevocationStatusList,
-    Schema as ACSchema,
     RevocationRegistryDefinition,
+    RevocationStatusList,
 )
-from indy_vdr import Request
-from indy_vdr import ledger
+from anoncreds import (
+    Schema as ACSchema,
+)
+from indy_vdr import Request, ledger
 
 from did_indy.did import parse_did_indy
 from did_indy.models.anoncreds import (
+    CredDef,
     RevRegDef,
     RevStatusList,
     Schema,
-    CredDef,
 )
 from did_indy.models.txn import CredDefTxnData, RevRegDefTxnData
 
@@ -148,6 +149,12 @@ def make_indy_cred_def_id(nym: str, type: str, schema_seq_no: int, tag: str) -> 
 def make_cred_def_id(did: str, ref: int | str, tag: str) -> str:
     """Make cred def ID."""
     return f"{did}/anoncreds/v0/CLAIM_DEF/{ref}/{tag}"
+
+
+def make_cred_def_id_from_indy(namespace: str, indy_cred_def_id) -> str:
+    """Make cred def ID."""
+    nym, _, _, ref, tag = indy_cred_def_id.split(":")
+    return f"did:indy:{namespace}:{nym}/anoncreds/v0/CLAIM_DEF/{ref}/{tag}"
 
 
 def make_indy_cred_def_id_from_result(nym: str, cred_def: CredDefTxnData) -> str:

--- a/src/did_indy/author/author.py
+++ b/src/did_indy/author/author.py
@@ -35,7 +35,6 @@ from did_indy.driver.api.txns import (
     SchemaSubmitResponse,
     make_indy_cred_def_id_from_result,
 )
-from did_indy.resolver import Resolver
 from did_indy.signer import Signer
 from did_indy.ledger import Ledger, LedgerPool, LedgerTransactionError
 from did_indy.models.anoncreds import Schema
@@ -177,9 +176,9 @@ class Author(BaseAuthor):
                 f"Failed to get signer for DID {cred_def.issuer_id}"
             ) from err
 
-        async with Ledger(pool) as ledger, Resolver(pool) as resolver:
+        async with Ledger(pool) as ledger:
             try:
-                schema_deref = await resolver.get_schema(cred_def.schema_id)
+                schema_deref = await ledger.deref_schema(cred_def.schema_id)
             except LedgerTransactionError as error:
                 LOGGER.exception("Failed to retrieve schema")
                 raise AuthorError(f"Cannot retrieve schema: {error}") from error

--- a/src/did_indy/author/resolver_lite.py
+++ b/src/did_indy/author/resolver_lite.py
@@ -5,9 +5,10 @@ from typing import Any
 
 from did_indy.client.client import IndyDriverClient
 from did_indy.models.anoncreds import CredDef, RevRegDef, RevStatusList, Schema
+from did_indy.resolver import ResolverProto
 
 
-class ResolverLite:
+class ResolverLite(ResolverProto):
     """Lite resolver.
 
     This resolver relies on a driver for resolving and dereferencing objects.

--- a/src/did_indy/author/resolver_lite.py
+++ b/src/did_indy/author/resolver_lite.py
@@ -1,0 +1,47 @@
+"""Lite resolver implementation."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from did_indy.client.client import IndyDriverClient
+from did_indy.models.anoncreds import CredDef, RevRegDef, RevStatusList, Schema
+
+
+class ResolverLite:
+    """Lite resolver.
+
+    This resolver relies on a driver for resolving and dereferencing objects.
+    This is a very simple class which exists primarily to mirror the full resolver
+    interface.
+    """
+
+    def __init__(self, client: IndyDriverClient):
+        """Init the resolver."""
+        self.client = client
+
+    async def resolve_did(self, did: str) -> Mapping[str, Any]:
+        """Resolve a DID."""
+        return await self.client.resolve_did(did)
+
+    async def get_schema(self, schema_id: str) -> Schema:
+        """Dereference a schema."""
+        return await self.client.dereference_schema(schema_id)
+
+    async def get_cred_def(self, cred_def_id: str) -> CredDef:
+        """Dereference a cred def."""
+        return await self.client.dereference_cred_def(cred_def_id)
+
+    async def get_rev_reg_def(self, rev_reg_def_id: str) -> RevRegDef:
+        """Dereference a rev reg def."""
+        return await self.client.dereference_rev_reg_def(rev_reg_def_id)
+
+    async def get_rev_status_list(
+        self,
+        rev_reg_def_id: str,
+        timestamp_from: int | None = 0,
+        timestamp_to: int | None = None,
+    ) -> RevStatusList:
+        """Resolve a revocation status list."""
+        return await self.client.resolve_rev_status_list(
+            rev_reg_def_id, timestamp_from, timestamp_to
+        )

--- a/src/did_indy/client/client.py
+++ b/src/did_indy/client/client.py
@@ -1,6 +1,7 @@
 """Client to did:indy driver."""
 
 from base64 import urlsafe_b64encode
+from collections.abc import Mapping
 from datetime import date, datetime, timezone
 import logging
 from typing import Any, List, Optional
@@ -16,7 +17,9 @@ from did_indy.driver.api.txns import (
     SchemaSubmitResponse,
     TxnToSignResponse,
 )
+from did_indy.models.anoncreds import CredDef, RevRegDef, RevStatusList, Schema
 from did_indy.models.endorsement import Endorsement
+
 
 from .http import HTTPClient
 
@@ -433,3 +436,48 @@ class IndyDriverClient(HTTPClient):
             response=EndorseResponse,
         )
         return Endorsement(result.nym, result.get_signature_bytes())
+
+    async def resolve_did(self, did: str) -> Mapping[str, Any]:
+        """Resolve a DID."""
+        return await self.post("/resolve", json={"did": did})
+
+    async def dereference_schema(self, schema_id: str) -> Schema:
+        """Dereference a schema."""
+        return await self.post(
+            "/dereference/schema",
+            json={"schema_id": schema_id},
+            response=Schema,
+        )
+
+    async def dereference_cred_def(self, cred_def_id: str) -> CredDef:
+        """Dereference a cred def."""
+        return await self.post(
+            "/dereference/cred-def",
+            json={"cred_def_id": cred_def_id},
+            response=CredDef,
+        )
+
+    async def dereference_rev_reg_def(self, rev_reg_def_id: str) -> RevRegDef:
+        """Dereference a rev reg def."""
+        return await self.post(
+            "/dereference/rev-reg-def",
+            json={"rev_reg_def_id": rev_reg_def_id},
+            response=RevRegDef,
+        )
+
+    async def resolve_rev_status_list(
+        self,
+        rev_reg_def_id: str,
+        timestamp_from: int | None = 0,
+        timestamp_to: int | None = None,
+    ) -> RevStatusList:
+        """Resolve a revocation status list."""
+        return await self.post(
+            "/resolve/rev-status-list",
+            json={
+                "rev_reg_def_id": rev_reg_def_id,
+                "timestamp_from": timestamp_from,
+                "timestamp_to": timestamp_to,
+            },
+            response=RevStatusList,
+        )

--- a/src/did_indy/did.py
+++ b/src/did_indy/did.py
@@ -1,8 +1,8 @@
 """DID Parsing and DID/Nym utils."""
 
+import re
 from dataclasses import dataclass
 from hashlib import sha256
-import re
 
 from base58 import b58decode, b58encode
 
@@ -14,6 +14,31 @@ class DidIndy:
     namespace: str
     nym: str
     did: str
+
+
+def parse_namespace_from_did(did: str) -> str:
+    """Extract namespace from did."""
+    if not did.startswith("did:indy:"):
+        raise ValueError(f"{did} is not a did:indy")
+
+    method_and_namespace, _ = did.rsplit(":", maxsplit=1)
+    namespace = method_and_namespace.removeprefix("did:indy:")
+    return namespace
+
+
+def strip_url(did_url: str) -> str:
+    """Extract did portion of a did url."""
+    did, _ = re.split(r"/|\?|#", did_url, maxsplit=1)
+    return did
+
+
+def parse_namespace_from_did_url(did_url: str) -> str:
+    """Extract namespace from did url."""
+    if not did_url.startswith("did:indy:"):
+        raise ValueError(f"{did_url} is not a did:indy URL")
+
+    did = strip_url(did_url)
+    return parse_namespace_from_did(did)
 
 
 def parse_did_indy(did: str) -> DidIndy:
@@ -31,7 +56,7 @@ def parse_did_indy_from_url(did_url: str) -> DidIndy:
     if not did_url.startswith("did:indy:"):
         raise ValueError(f"{did_url} is not a did:indy URL")
 
-    did, _ = re.split(r"/|\?|#", did_url, maxsplit=1)
+    did = strip_url(did_url)
     method_and_namespace, nym = did.rsplit(":", maxsplit=1)
     namespace = method_and_namespace.removeprefix("did:indy:")
     return DidIndy(namespace, nym, did)

--- a/src/did_indy/did.py
+++ b/src/did_indy/did.py
@@ -13,6 +13,7 @@ class DidIndy:
 
     namespace: str
     nym: str
+    did: str
 
 
 def parse_did_indy(did: str) -> DidIndy:
@@ -22,7 +23,7 @@ def parse_did_indy(did: str) -> DidIndy:
 
     method_and_namespace, nym = did.rsplit(":", maxsplit=1)
     namespace = method_and_namespace.removeprefix("did:indy:")
-    return DidIndy(namespace, nym)
+    return DidIndy(namespace, nym, did)
 
 
 def parse_did_indy_from_url(did_url: str) -> DidIndy:
@@ -33,7 +34,7 @@ def parse_did_indy_from_url(did_url: str) -> DidIndy:
     did, _ = re.split(r"/|\?|#", did_url, maxsplit=1)
     method_and_namespace, nym = did.rsplit(":", maxsplit=1)
     namespace = method_and_namespace.removeprefix("did:indy:")
-    return DidIndy(namespace, nym)
+    return DidIndy(namespace, nym, did)
 
 
 def nym_from_verkey(verkey: str, version: int = 2) -> str:

--- a/src/did_indy/driver/api/resolver.py
+++ b/src/did_indy/driver/api/resolver.py
@@ -1,14 +1,12 @@
 """Resolver API."""
 
-from fastapi import APIRouter, HTTPException, Security
+from fastapi import APIRouter, Security
 from pydantic import BaseModel
 
-from did_indy.did import parse_did_indy, parse_did_indy_from_url
 from did_indy.driver.auto_endorse import SCOPE_RESOLVE
-from did_indy.driver.depends import LedgersDep
+from did_indy.driver.depends import ResolverDep
 from did_indy.driver.security import client
 from did_indy.models.anoncreds import CredDef, RevRegDef, RevStatusList, Schema
-from did_indy.resolver import Resolver
 
 router = APIRouter(tags=["Resolver"])
 
@@ -16,18 +14,11 @@ router = APIRouter(tags=["Resolver"])
 @router.get("/resolve/{did}")
 async def get_resolve_did(
     did: str,
-    ledgers: LedgersDep,
+    resolver: ResolverDep,
     _=Security(client, scopes=[SCOPE_RESOLVE]),
 ):
     """Resolve a did:indy DID."""
-    parsed = parse_did_indy(did)
-
-    pool = ledgers.get(parsed.namespace)
-    if not pool:
-        raise HTTPException(404, detail=f"Namespace {parsed.namespace} is unknown")
-
-    async with Resolver(pool) as resolver:
-        result = await resolver.resolve_did(did)
+    result = await resolver.resolve_did(did)
 
     return result
 
@@ -41,7 +32,7 @@ class ResolveRequest(BaseModel):
 @router.post("/resolve")
 async def post_resolve(
     req: ResolveRequest,
-    ledgers: LedgersDep,
+    resolver: ResolverDep,
     _=Security(client, scopes=[SCOPE_RESOLVE]),
 ):
     """Resolve a did:indy DID.
@@ -49,14 +40,7 @@ async def post_resolve(
     This does exactly the same resolution as `GET /resolve/{did}` but uses the
     request body to send the DID to avoid having to encode the did.
     """
-    parsed = parse_did_indy(req.did)
-
-    pool = ledgers.get(parsed.namespace)
-    if not pool:
-        raise HTTPException(404, detail=f"Namespace {parsed.namespace} is unknown")
-
-    async with Resolver(pool) as resolver:
-        result = await resolver.resolve_did(req.did)
+    result = await resolver.resolve_did(req.did)
 
     return result
 
@@ -70,18 +54,11 @@ class SchemaDerefRequest(BaseModel):
 @router.post("/dereference/schema")
 async def post_dereference_schema(
     req: SchemaDerefRequest,
-    ledgers: LedgersDep,
+    resolver: ResolverDep,
     _=Security(client, scopes=[SCOPE_RESOLVE]),
 ) -> Schema:
     """Dereference a DID URL."""
-    parsed = parse_did_indy_from_url(req.schema_id)
-
-    pool = ledgers.get(parsed.namespace)
-    if not pool:
-        raise HTTPException(404, detail=f"Namespace {parsed.namespace} is unknown")
-
-    async with Resolver(pool) as resolver:
-        result = await resolver.get_schema(req.schema_id)
+    result = await resolver.get_schema(req.schema_id)
 
     return result
 
@@ -95,18 +72,11 @@ class CredDefDerefRequest(BaseModel):
 @router.post("/dereference/cred-def")
 async def post_dereference_cred_def(
     req: CredDefDerefRequest,
-    ledgers: LedgersDep,
+    resolver: ResolverDep,
     _=Security(client, scopes=[SCOPE_RESOLVE]),
 ) -> CredDef:
     """Dereference a DID URL."""
-    parsed = parse_did_indy_from_url(req.cred_def_id)
-
-    pool = ledgers.get(parsed.namespace)
-    if not pool:
-        raise HTTPException(404, detail=f"Namespace {parsed.namespace} is unknown")
-
-    async with Resolver(pool) as resolver:
-        result = await resolver.get_cred_def(req.cred_def_id)
+    result = await resolver.get_cred_def(req.cred_def_id)
 
     return result
 
@@ -120,18 +90,11 @@ class RevRegDefDerefRequest(BaseModel):
 @router.post("/dereference/rev-reg-def")
 async def post_dereference_rev_reg_def(
     req: RevRegDefDerefRequest,
-    ledgers: LedgersDep,
+    resolver: ResolverDep,
     _=Security(client, scopes=[SCOPE_RESOLVE]),
 ) -> RevRegDef:
     """Dereference a DID URL."""
-    parsed = parse_did_indy_from_url(req.rev_reg_def_id)
-
-    pool = ledgers.get(parsed.namespace)
-    if not pool:
-        raise HTTPException(404, detail=f"Namespace {parsed.namespace} is unknown")
-
-    async with Resolver(pool) as resolver:
-        result = await resolver.get_rev_reg_def(req.rev_reg_def_id)
+    result = await resolver.get_rev_reg_def(req.rev_reg_def_id)
 
     return result
 
@@ -147,21 +110,14 @@ class ResolveRevStatusListRequest(BaseModel):
 @router.post("/resolve/rev-status-list")
 async def post_resolve_rev_status_list(
     req: ResolveRevStatusListRequest,
-    ledgers: LedgersDep,
+    resolver: ResolverDep,
     _=Security(client, scopes=[SCOPE_RESOLVE]),
 ) -> RevStatusList:
     """Resolve a revocation status list."""
-    parsed = parse_did_indy_from_url(req.rev_reg_def_id)
-
-    pool = ledgers.get(parsed.namespace)
-    if not pool:
-        raise HTTPException(404, detail=f"Namespace {parsed.namespace} is unknown")
-
-    async with Resolver(pool) as resolver:
-        result = await resolver.get_rev_status_list(
-            rev_reg_def_id=req.rev_reg_def_id,
-            timestamp_from=req.timestamp_from,
-            timestamp_to=req.timestamp_to,
-        )
+    result = await resolver.get_rev_status_list(
+        rev_reg_def_id=req.rev_reg_def_id,
+        timestamp_from=req.timestamp_from,
+        timestamp_to=req.timestamp_to,
+    )
 
     return result

--- a/src/did_indy/driver/api/txns.py
+++ b/src/did_indy/driver/api/txns.py
@@ -39,6 +39,7 @@ from did_indy.driver.taa import get_latest_txn_author_acceptance
 from did_indy.ledger import (
     Ledger,
     LedgerTransactionError,
+    ReadOnlyLedger,
 )
 from did_indy.models.anoncreds import CredDef, RevRegDef, RevStatusList, Schema
 from did_indy.models.taa import TaaAcceptance
@@ -55,7 +56,6 @@ from did_indy.models.txn import (
     TxnRequest,
     TxnResult,
 )
-from did_indy.resolver import Resolver
 
 router = APIRouter(prefix="/txn")
 LOGGER = logging.getLogger(__name__)
@@ -360,9 +360,9 @@ async def post_cred_def(
     if not pool:
         raise HTTPException(404, f"No ledger known for namespace {submitter.namespace}")
 
-    async with Resolver(pool) as resolver:
+    async with ReadOnlyLedger(pool) as ledger:
         try:
-            schema_deref = await resolver.get_schema(req.cred_def.schema_id)
+            schema_deref = await ledger.deref_schema(req.cred_def.schema_id)
         except LedgerTransactionError as error:
             raise HTTPException(400, f"Cannot retrieve schema: {error}") from error
 

--- a/src/did_indy/driver/app.py
+++ b/src/did_indy/driver/app.py
@@ -1,12 +1,13 @@
 import logging.config
 from os import getenv
+
 from fastapi import FastAPI
 
 from did_indy.driver.config import Config
 from did_indy.driver.depends import lifespan
 
+from .api import clients, namespaces, resolver, txns
 from .webhooks import webhooks
-from .api import txns, namespaces, clients
 
 LOG_LEVEL = getenv("LOG_LEVEL", "DEBUG")
 logging.config.dictConfig(
@@ -97,3 +98,4 @@ if config.auth == "client-tokens":
 
 app.include_router(namespaces.router)
 app.include_router(txns.router)
+app.include_router(resolver.router)

--- a/src/did_indy/driver/ledgers.py
+++ b/src/did_indy/driver/ledgers.py
@@ -46,6 +46,14 @@ async def get_nym_and_key(store: Store, namespace: str) -> Tuple[str, Key]:
     return nym, key
 
 
+class UnknownNamespaceError(Exception):
+    """Raised when an unknown namespace is encountered."""
+
+    def __init__(self, namespace: str):
+        """Init exception."""
+        self.namespace = namespace
+
+
 class Ledgers:
     """Registry of ledgers, identified by namespace."""
 
@@ -56,6 +64,18 @@ class Ledgers:
         """Add to the registry."""
         self.ledgers[namespace] = pool
 
-    def get(self, namespace: str) -> LedgerPool | None:
+    def get_or(self, namespace: str) -> LedgerPool | None:
         """Get a ledger by namespace."""
         return self.ledgers.get(namespace)
+
+    def get(self, namespace: str) -> LedgerPool:
+        """Get a ledger by namespace."""
+        pool = self.ledgers.get(namespace)
+        if not pool:
+            raise UnknownNamespaceError(namespace)
+
+        return pool
+
+    def get_pool(self, namespace: str) -> LedgerPool:
+        """Alias to match PoolProvider protocol."""
+        return self.get(namespace)

--- a/src/did_indy/ledger.py
+++ b/src/did_indy/ledger.py
@@ -19,7 +19,7 @@ from did_indy.cache import Cache
 from did_indy.config import LocalLedgerGenesis, RemoteLedgerGenesis
 from did_indy.models.endorsement import Endorsement
 from did_indy.models.taa import TaaAcceptance, TAAInfo, TAARecord
-from did_indy.models.txn.data import SchemaTxnDataData
+from did_indy.models.txn.data import SchemaTxnData
 from did_indy.models.txn.deref import (
     CredDefDeref,
     GetRevRegDefReply,
@@ -411,15 +411,15 @@ class BaseLedger:
         schema_result = SchemaDeref.model_validate(result)
         return schema_result
 
-    async def get_schema_by_seq_no(self, seq_no: int) -> GetTxnReply[SchemaTxnDataData]:
+    async def get_schema_by_seq_no(self, seq_no: int) -> GetTxnReply[SchemaTxnData]:
         request = ledger.build_get_txn_request(
             submitter_did=None,
             ledger_type=LedgerType.DOMAIN,
             seq_no=seq_no,
         )
         result = await self.get(request)
-        response = NodeResponse[GetTxnReply[SchemaTxnDataData]].model_validate(result)
-        return response.result
+        response = GetTxnReply[SchemaTxnData].model_validate(result)
+        return response
 
     async def deref_cred_def(self, cred_def_id: str) -> CredDefDeref:
         """Retrieve cred def by ID (DID URL)."""

--- a/src/did_indy/ledger.py
+++ b/src/did_indy/ledger.py
@@ -3,19 +3,31 @@
 import asyncio
 import base64
 import hashlib
+import json
 import logging
 import os
 import tempfile
 from io import StringIO
 from pathlib import Path
+from time import time
 from typing import Optional, TypeVar, cast
 
-from indy_vdr import Pool, Request, VdrError, ledger, open_pool
+from indy_vdr import LedgerType, Pool, Request, VdrError, ledger, open_pool
+from indy_vdr.bindings import dereference
 
 from did_indy.cache import Cache
 from did_indy.config import LocalLedgerGenesis, RemoteLedgerGenesis
 from did_indy.models.endorsement import Endorsement
 from did_indy.models.taa import TaaAcceptance, TAAInfo, TAARecord
+from did_indy.models.txn.data import SchemaTxnDataData
+from did_indy.models.txn.deref import (
+    CredDefDeref,
+    GetRevRegDefReply,
+    GetTxnReply,
+    NodeResponse,
+    RevRegDefDeref,
+    SchemaDeref,
+)
 from did_indy.signer import Signer, sign_message
 from did_indy.utils import FetchError, fetch
 
@@ -379,6 +391,185 @@ class BaseLedger:
             )
 
         return TAAInfo(aml=aml_found, taa=taa_record, required=taa_required)
+
+    async def dereference(self, did_url: str) -> dict:
+        """Dereference a DID URL to an object."""
+        if not self.pool.handle or not self.pool.handle.handle:
+            raise ClosedPoolError(
+                f"Cannot dereference using a closed pool '{self.pool.name}'"
+            )
+
+        try:
+            result = json.loads(await dereference(self.pool.handle.handle, did_url))
+        except VdrError as err:
+            raise LedgerError("Ledger request error") from err
+        return result
+
+    async def deref_schema(self, schema_id: str) -> SchemaDeref:
+        """Retrieve schema by ID (DID URL)."""
+        result = await self.dereference(schema_id)
+        schema_result = SchemaDeref.model_validate(result)
+        return schema_result
+
+    async def get_schema_by_seq_no(self, seq_no: int) -> GetTxnReply[SchemaTxnDataData]:
+        request = ledger.build_get_txn_request(
+            submitter_did=None,
+            ledger_type=LedgerType.DOMAIN,
+            seq_no=seq_no,
+        )
+        result = await self.get(request)
+        response = NodeResponse[GetTxnReply[SchemaTxnDataData]].model_validate(result)
+        return response.result
+
+    async def deref_cred_def(self, cred_def_id: str) -> CredDefDeref:
+        """Retrieve cred def by ID (DID URL)."""
+        result = await self.dereference(cred_def_id)
+        cred_def_result = CredDefDeref.model_validate(result)
+        return cred_def_result
+
+    async def deref_rev_reg_def(self, rev_reg_def_id: str) -> RevRegDefDeref:
+        """Retrieve a rev reg def by ID (DID URL)."""
+        result = await self.dereference(rev_reg_def_id)
+        rev_reg_def_result = RevRegDefDeref.model_validate(result)
+        return rev_reg_def_result
+
+    # --- Get Revocation Status List Helpers
+    # These are all necessary since we don't have a convenient helper like dereference
+    # for status lists since they're identified by rev_reg_def_id and time range.
+
+    async def deref_revoc_reg_entry(
+        self, indy_rev_reg_def_id: str, timestamp: int
+    ) -> tuple[dict, int]:
+        """Get revocation registry entry by rev reg def id and timestamp."""
+        if not self.pool.handle or not self.pool.handle.handle:
+            raise ClosedPoolError(
+                f"Cannot submit get request to closed pool '{self.pool.name}'"
+            )
+
+        request = ledger.build_get_revoc_reg_request(
+            submitter_did=None,
+            revoc_reg_id=indy_rev_reg_def_id,
+            timestamp=timestamp,
+        )
+        try:
+            response = await self.pool.handle.submit_request(request)
+        except VdrError as err:
+            raise LedgerError(
+                f"Failed to retrieve rev entry for {indy_rev_reg_def_id}"
+            ) from err
+
+        ledger_timestamp = response["data"]["txnTime"]
+        reg_entry = {
+            "ver": "1.0",
+            "value": response["data"]["value"],
+        }
+        if response["data"]["revocRegDefId"] != indy_rev_reg_def_id:
+            raise LedgerError(
+                "ID of revocation registry response does not match requested ID"
+            )
+        return reg_entry, ledger_timestamp
+
+    async def fetch_revoc_reg_delta(
+        self,
+        indy_rev_reg_def_id: str,
+        timestamp_from: int | None,
+        timestamp_to: int | None,
+    ) -> dict:
+        """Get revocation registry definition from ledger."""
+        if not self.pool.handle or not self.pool.handle.handle:
+            raise ClosedPoolError(
+                f"Cannot submit get request to closed pool '{self.pool.name}'"
+            )
+
+        if timestamp_to is None:
+            timestamp_to = int(time())
+
+        request = ledger.build_get_revoc_reg_delta_request(
+            submitter_did=None,
+            revoc_reg_id=indy_rev_reg_def_id,
+            from_ts=timestamp_from,
+            to_ts=timestamp_to,
+        )
+        try:
+            response = await self.pool.handle.submit_request(request)
+        except VdrError as err:
+            raise LedgerError(
+                f"Failed to retrieve rev_status_list for {indy_rev_reg_def_id}"
+            ) from err
+
+        response_value = response["data"]["value"]
+        if response_value["data"]["revocRegDefId"] != indy_rev_reg_def_id:
+            raise LedgerError(
+                "ID of revocation registry response does not match requested ID"
+            )
+        return response_value
+
+    async def get_revoc_reg_delta(
+        self,
+        indy_rev_reg_def_id: str,
+        timestamp_from: int | None,
+        timestamp_to: int | None,
+    ) -> tuple[dict, int]:
+        """Get revocation registry delta, with checks to correct time to reg creation."""
+        response = await self.fetch_revoc_reg_delta(
+            indy_rev_reg_def_id,
+            timestamp_from,
+            timestamp_to,
+        )
+
+        # If accum_to is not present, then the timestamp_to was before the registry
+        # was created. In this case, we need to fetch the registry creation timestamp and
+        # re-calculate the delta.
+        if not response.get("accum_to"):
+            _, timestamp_to = await self.deref_revoc_reg_entry(
+                indy_rev_reg_def_id, int(time())
+            )
+            response = await self.fetch_revoc_reg_delta(
+                indy_rev_reg_def_id, timestamp_from, timestamp_to
+            )
+
+        delta = {
+            "accum": response["accum_to"]["value"]["accum"],
+            "issued": response.get("issued", []),
+            "revoked": response.get("revoked", []),
+        }
+        accum_from = response.get("accum_from")
+        if accum_from:
+            delta["prev_accum"] = accum_from["value"]["accum"]
+        reg_delta = {"ver": "1.0", "value": delta}
+        # question - why not response["to"] ?
+        delta_timestamp = response["accum_to"]["txnTime"]
+        return reg_delta, delta_timestamp
+
+    async def get_or_fetch_rev_reg_def_max_cred_num(
+        self, indy_rev_reg_def_id: str
+    ) -> int:
+        """Retrieve max cred num for a rev reg def.
+
+        The value is retrieved from cache or from the ledger if necessary.
+        The issuer could retrieve this value from the wallet but this info
+        must also be known to the holder.
+        """
+        cache = self.pool.cache
+        cache_key = f"rev_reg_max_cred_num::{indy_rev_reg_def_id}"
+
+        max_cred_num = await cache.get(cache_key)
+        if max_cred_num:
+            return max_cred_num
+
+        request = ledger.build_get_revoc_reg_def_request(
+            submitter_did=None,
+            revoc_reg_id=indy_rev_reg_def_id,
+        )
+        result = await self.get(request)
+        response = NodeResponse[GetRevRegDefReply].model_validate(result)
+        max_cred_num = response.result.data.value.max_cred_num
+
+        await cache.set(cache_key, max_cred_num)
+
+        return max_cred_num
+
+    # --- END Get Revocation Status List Helpers
 
 
 class ReadOnlyLedger(BaseLedger):

--- a/src/did_indy/ledger.py
+++ b/src/did_indy/ledger.py
@@ -24,7 +24,6 @@ from did_indy.models.txn.deref import (
     CredDefDeref,
     GetRevRegDefReply,
     GetTxnReply,
-    NodeResponse,
     RevRegDefDeref,
     SchemaDeref,
 )
@@ -496,12 +495,13 @@ class BaseLedger:
             raise LedgerError(
                 f"Failed to retrieve rev_status_list for {indy_rev_reg_def_id}"
             ) from err
+        LOGGER.debug("revoc_reg_delta response: %s", response)
 
-        response_value = response["data"]["value"]
-        if response_value["data"]["revocRegDefId"] != indy_rev_reg_def_id:
+        if response["data"]["revocRegDefId"] != indy_rev_reg_def_id:
             raise LedgerError(
                 "ID of revocation registry response does not match requested ID"
             )
+        response_value = response["data"]["value"]
         return response_value
 
     async def get_revoc_reg_delta(
@@ -562,8 +562,8 @@ class BaseLedger:
             revoc_reg_id=indy_rev_reg_def_id,
         )
         result = await self.get(request)
-        response = NodeResponse[GetRevRegDefReply].model_validate(result)
-        max_cred_num = response.result.data.value.max_cred_num
+        response = GetRevRegDefReply.model_validate(result)
+        max_cred_num = response.data.value.max_cred_num
 
         await cache.set(cache_key, max_cred_num)
 

--- a/src/did_indy/models/txn/deref.py
+++ b/src/did_indy/models/txn/deref.py
@@ -7,6 +7,8 @@ from typing import Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
 
+from did_indy.models.txn.result import TxnResult
+
 from .data import (
     CredDefTxnDataData,
     RevRegDefTxnData,
@@ -88,3 +90,15 @@ class DereferenceResult(BaseModel, Generic[ContentStream, ContentMetadata]):
 SchemaDeref = DereferenceResult[SchemaTxnDataData, GetSchemaReply]
 CredDefDeref = DereferenceResult[CredDefTxnDataData, GetCredDefReply]
 RevRegDefDeref = DereferenceResult[RevRegDefTxnData, GetRevRegDefReply]
+
+Txn = TypeVar("Txn", bound=BaseModel)
+
+
+class GetTxnReply(BaseModel, Generic[Txn]):
+    """Get txn reply."""
+
+    type: str
+    identifier: str
+    reqId: int
+    seqNo: int
+    data: TxnResult[Txn]

--- a/src/did_indy/resolver.py
+++ b/src/did_indy/resolver.py
@@ -3,10 +3,22 @@
 import json
 
 from indy_vdr import VdrError
-from indy_vdr.bindings import dereference, resolve
+from indy_vdr.bindings import resolve
 
-from did_indy.ledger import ClosedPoolError, LedgerPool
-from did_indy.models.txn import CredDefDeref, RevRegDefDeref, SchemaDeref
+from did_indy.anoncreds import (
+    make_cred_def_id_from_indy,
+    make_indy_rev_reg_def_id_from_did_url,
+    make_schema_id,
+)
+from did_indy.did import parse_did_indy_from_url
+from did_indy.ledger import ClosedPoolError, LedgerPool, ReadOnlyLedger
+from did_indy.models.anoncreds import (
+    CredDef,
+    RevRegDef,
+    RevRegDefValue,
+    RevStatusList,
+    Schema,
+)
 
 
 class ResolverError(Exception):
@@ -33,12 +45,10 @@ class Resolver:
         """Context manager exit."""
         await self.pool.context_close()
 
-    async def resolve(self, did: str) -> dict:
+    async def resolve_did(self, did: str) -> dict:
         """Resolve a did:indy DID."""
         if not self.pool.handle or not self.pool.handle.handle:
-            raise ClosedPoolError(
-                f"Cannot sign and submit request to closed pool '{self.pool.name}'"
-            )
+            raise ClosedPoolError(f"Cannot resolve from closed pool '{self.pool.name}'")
 
         try:
             result = json.loads(await resolve(self.pool.handle.handle, did))  # pyright: ignore
@@ -46,33 +56,118 @@ class Resolver:
             raise ResolverError("Ledger request error") from err
         return result
 
-    async def dereference(self, did_url: str) -> dict:
-        """Dereference a DID URL to an object."""
-        if not self.pool.handle or not self.pool.handle.handle:
-            raise ClosedPoolError(
-                f"Cannot sign and submit request to closed pool '{self.pool.name}'"
-            )
-
-        try:
-            result = json.loads(await dereference(self.pool.handle.handle, did_url))
-        except VdrError as err:
-            raise ResolverError("Ledger request error") from err
-        return result
-
-    async def get_schema(self, schema_id: str) -> SchemaDeref:
+    async def get_schema(self, schema_id: str) -> Schema:
         """Retrieve schema by ID (DID URL)."""
-        result = await self.dereference(schema_id)
-        schema_result = SchemaDeref.model_validate(result)
-        return schema_result
+        ledger = ReadOnlyLedger(self.pool)  # pool should already be open
+        deref = await ledger.deref_schema(schema_id)
+        did_indy = parse_did_indy_from_url(schema_id)
+        return Schema(
+            issuer_id=did_indy.did,
+            attr_names=deref.contentStream.attr_names,
+            name=deref.contentStream.name,
+            version=deref.contentStream.version,
+        )
 
-    async def get_cred_def(self, cred_def_id: str) -> CredDefDeref:
-        """Retrieve cred def by ID (DID URL)."""
-        result = await self.dereference(cred_def_id)
-        cred_def_result = CredDefDeref.model_validate(result)
-        return cred_def_result
+    async def _get_or_fetch_schema_id_by_seq_no(
+        self, ledger: ReadOnlyLedger, namespace: str, seq_no: int
+    ) -> str:
+        """Retrieve schema id by seqNo from cache or ledger."""
+        cache = self.pool.cache
+        cache_key = f"schema_id_by_seq_no::{namespace}::{seq_no}"
 
-    async def get_rev_reg_def(self, rev_reg_def_id: str) -> RevRegDefDeref:
+        schema_id = await cache.get(cache_key)
+        if schema_id:
+            return schema_id
+
+        schema_ish = await ledger.get_schema_by_seq_no(seq_no)
+
+        schema_nym = schema_ish.identifier
+        schema_data = schema_ish.data.txn.data
+        schema_issuer_id = f"did:indy:{namespace}:{schema_nym}"
+
+        schema_id = make_schema_id(
+            issuer_id=schema_issuer_id,
+            name=schema_data.name,
+            version=schema_data.version,
+        )
+        return schema_id
+
+    async def get_cred_def(self, cred_def_id: str) -> CredDef:
+        """Retrieve cred def by ID (DID URL).
+
+        Returning a CredDef is complicated because of needing to determine the full
+        schema_id when only the seqNo of the schema is found in the cred def dereference
+        result as `ref`. It is further complicated by the data structure of the result of
+        retrieving a txn by seqNo is very different from the structure of a dereferenced
+        schema. So lots of shuffling and mapping pieces onto each other is required.
+        """
+        did_indy = parse_did_indy_from_url(cred_def_id)
+        ledger = ReadOnlyLedger(self.pool)  # pool should already be open
+        deref = await ledger.deref_cred_def(cred_def_id)
+        schema_id = await self._get_or_fetch_schema_id_by_seq_no(
+            ledger, did_indy.namespace, deref.contentMetadata.nodeResponse.result.ref
+        )
+
+        return CredDef(
+            issuer_id=did_indy.did,
+            schema_id=schema_id,
+            type="CL",
+            tag=deref.contentMetadata.nodeResponse.result.tag,
+            value=deref.contentMetadata.nodeResponse.result.data.model_dump(),
+        )
+
+    async def get_rev_reg_def(self, rev_reg_def_id: str) -> RevRegDef:
         """Retrieve a rev reg def by ID (DID URL)."""
-        result = await self.dereference(rev_reg_def_id)
-        rev_reg_def_result = RevRegDefDeref.model_validate(result)
-        return rev_reg_def_result
+        ledger = ReadOnlyLedger(self.pool)  # pool should already be open
+        deref = await ledger.deref_rev_reg_def(rev_reg_def_id)
+        did_indy = parse_did_indy_from_url(rev_reg_def_id)
+        cred_def_id = make_cred_def_id_from_indy(
+            did_indy.namespace, deref.contentStream.cred_def_id
+        )
+        value = deref.contentStream.value
+        return RevRegDef(
+            issuer_id=did_indy.did,
+            revoc_def_type="CL_ACCUM",
+            cred_def_id=cred_def_id,
+            tag=deref.contentStream.tag,
+            value=RevRegDefValue(
+                max_cred_num=value.max_cred_num,
+                public_keys=value.public_keys,
+                tails_hash=value.tails_hash,
+                tails_location=value.tails_location,
+            ),
+        )
+
+    def _indexes_to_bit_array(self, indexes: list[int], size: int) -> list[int]:
+        """Turn a sequence of indexes into a full state bit array."""
+        return [1 if index in indexes else 0 for index in range(0, size + 1)]
+
+    async def get_rev_status_list(
+        self,
+        rev_reg_def_id: str,
+        timestamp_from: int | None = 0,
+        timestamp_to: int | None = None,
+    ) -> RevStatusList:
+        """Retrieve a rev status list by rev reg def id and time range."""
+        indy_rev_reg_def_id = make_indy_rev_reg_def_id_from_did_url(rev_reg_def_id)
+        ledger = ReadOnlyLedger(self.pool)
+        delta, timestamp = await ledger.get_revoc_reg_delta(
+            indy_rev_reg_def_id=indy_rev_reg_def_id,
+            timestamp_from=timestamp_from,
+            timestamp_to=timestamp_to,
+        )
+
+        max_cred_num = await ledger.get_or_fetch_rev_reg_def_max_cred_num(
+            indy_rev_reg_def_id
+        )
+        revocation_list_from_indexes = self._indexes_to_bit_array(
+            delta["value"]["revoked"], max_cred_num
+        )
+        did_indy = parse_did_indy_from_url(rev_reg_def_id)
+        return RevStatusList(
+            issuer_id=did_indy.did,
+            rev_reg_def_id=rev_reg_def_id,
+            revocation_list=revocation_list_from_indexes,
+            current_accumulator=delta["value"]["accum"],
+            timestamp=timestamp,
+        )


### PR DESCRIPTION
One piece that's been missing from this library has been methods to resolve revocation lists and return them in AnonCreds-RS format.

As it turns out, that's rather complicated. As I was working through it, it necessitated thinking deeper about the separation of concerns between the `ReadOnlyLedger`/`Ledger` and the `Resolver`. The new split is this:

- Ledger: focuses on interacting with the ledger and returning values in indy/indy-vdr representations
- Resolver: focuses on the high-level operations, taking in DID URLs to objects and returning the AnonCreds-RS representation rather than an indy specific representation.

This partially reverts the recent changes I made introducing the resolver, which is a bummer since that likely requires changes downstream. But I think this makes more sense.

## Draft State

There's a little bit more to do to make the resolver easy to consume. It will probably mean another resolver wrapper that is namespace aware.